### PR TITLE
Bug in constructors of atca_iface.c and atca_command.h

### DIFF
--- a/lib/atca_command.c
+++ b/lib/atca_command.c
@@ -756,6 +756,11 @@ ATCACommand newATCACommand(ATCADeviceType device_type)    // constructor
     ATCACommand ca_cmd;
 
     ca_cmd = (ATCACommand)malloc(sizeof(atca_command));
+    if(ca_cmd == NULL)
+    {
+        return NULL;   
+    }
+    
     ca_cmd->dt = device_type;
     ca_cmd->clock_divider = 0;
     if (status != ATCA_SUCCESS)

--- a/lib/atca_iface.c
+++ b/lib/atca_iface.c
@@ -52,6 +52,11 @@ ATCAIface newATCAIface(ATCAIfaceCfg *cfg)  // constructor
     ATCAIface ca_iface;
 
     ca_iface = (ATCAIface)malloc(sizeof(struct atca_iface));
+    if(ca_iface == NULL)
+    {
+        return NULL;  
+    }
+   
     ca_iface->mType = cfg->iface_type;
     ca_iface->mIfaceCFG = cfg;
 


### PR DESCRIPTION
In the constructors of atca_iface.c and atca_command.h the returned pointer of malloc was never checked if it is NULL or not. This check has been added.