### PR TITLE
Compile with GNU ARM Embedded 6

### DIFF
--- a/lib/atca_command.h
+++ b/lib/atca_command.h
@@ -11,13 +11,13 @@
  * \copyright (c) 2015-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \page License
- * 
+ *
  * Subject to your compliance with these terms, you may use Microchip software
  * and any derivatives exclusively with Microchip products. It is your
  * responsibility to comply with third party license terms applicable to your
  * use of third party software (including open source software) that may
  * accompany Microchip software.
- * 
+ *
  * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER
  * EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY IMPLIED
  * WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS FOR A
@@ -34,6 +34,7 @@
 #ifndef ATCA_COMMAND_H
 #define ATCA_COMMAND_H
 
+#include "stddef.h"
 #include "atca_compiler.h"
 #include "atca_status.h"
 #include "atca_devtypes.h"

--- a/lib/atca_iface.h
+++ b/lib/atca_iface.h
@@ -6,13 +6,13 @@
  * \copyright (c) 2015-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \page License
- * 
+ *
  * Subject to your compliance with these terms, you may use Microchip software
  * and any derivatives exclusively with Microchip products. It is your
  * responsibility to comply with third party license terms applicable to your
  * use of third party software (including open source software) that may
  * accompany Microchip software.
- * 
+ *
  * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER
  * EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY IMPLIED
  * WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS FOR A
@@ -71,19 +71,19 @@ typedef struct
 
     union                           // each instance of an iface cfg defines a single type of interface
     {
-        struct ATCAI2C
+        struct
         {
             uint8_t  slave_address; // 8-bit slave address
             uint8_t  bus;           // logical i2c bus number, 0-based - HAL will map this to a pin pair for SDA SCL
             uint32_t baud;          // typically 400000
         } atcai2c;
 
-        struct ATCASWI
+        struct
         {
             uint8_t bus;        // logical SWI bus - HAL will map this to a pin	or uart port
         } atcaswi;
 
-        struct ATCAUART
+        struct
         {
             int      port;      // logic port number
             uint32_t baud;      // typically 115200
@@ -92,7 +92,7 @@ typedef struct
             uint8_t  stopbits;  // 0,1,2
         } atcauart;
 
-        struct ATCAHID
+        struct
         {
             int      idx;           // HID enumeration index
             uint32_t vid;           // Vendor ID of kit (0x03EB for CK101)
@@ -101,7 +101,7 @@ typedef struct
             uint8_t  guid[16];      // The GUID for this HID device
         } atcahid;
 
-        struct ATCACUSTOM
+        struct
         {
             ATCA_STATUS (*halinit)(void *hal, void *cfg);
             ATCA_STATUS (*halpostinit)(void *iface);


### PR DESCRIPTION
These were the changes that I required to make cryptoauthlib compile on Mbed OS 5 with GNU ARM Embedded 6. I assume the struct names in `atca_iface.h` are not required. The change in `atca_command.h` was required because `size_t` was not defined. 