### PR TITLE
Allow to build as either shared or static library

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,6 +6,8 @@ option(ATCA_HAL_KIT_HID "Include the HID HAL Driver")
 option(ATCA_HAL_I2C "Include the I2C Hal Driver - Linux & MCU only")
 option(ATCA_PRINTF "Enable Debug print statements in library")
 option(ATCA_PKCS11 "Build PKCS11 Library")
+option(ATCA_BUILD_SHARED_LIBS "Build CryptoAuthLib as shared library" ON)
+set(BUILD_SHARED_LIBS ${ATCA_BUILD_SHARED_LIBS})
 
 # Collect Library Sources
 file(GLOB LIB_SRC RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.c")
@@ -55,7 +57,7 @@ if(ATCA_PKCS11)
 set(CRYPTOAUTH_SRC ${CRYPTOAUTH_SRC} ${PKCS11_SRC})
 endif()
 
-add_library(cryptoauth SHARED ${CRYPTOAUTH_SRC} ${ATCACERT_DEF_SRC})
+add_library(cryptoauth ${CRYPTOAUTH_SRC} ${ATCACERT_DEF_SRC})
 
 # Add Remaining Sources depending on target library type
 if(ATCA_PKCS11)


### PR DESCRIPTION
#57

**To build as shared library (default):**
```
cmake  ..
```
```
[100%] Linking C shared library libcryptoauth.so
```

**To build as static library:**
```
$ cmake -DATCA_BUILD_SHARED_LIBS=OFF ..
```
```
[100%] Linking C static library libcryptoauth.a
```
