### PR TITLE
Secret-dependent comparisons should be constant-time #67

### DIFF
--- a/app/ip_protection/symmetric_authentication.c
+++ b/app/ip_protection/symmetric_authentication.c
@@ -124,7 +124,7 @@ ATCA_STATUS symmetric_authenticate(uint8_t slot, const uint8_t *master_key, cons
         }
 
         //Check whether the MAC calculated on host is same as that generated from the device
-        if (memcmp(device_mac, host_mac, 32) != 0)
+        if (atcab_memcmp(device_mac, host_mac, 32) != 0)
         {
             status = ATCA_CHECKMAC_VERIFY_FAILED;
         }

--- a/lib/basic/atca_basic_aes_gcm.c
+++ b/lib/basic/atca_basic_aes_gcm.c
@@ -571,7 +571,7 @@ ATCA_STATUS atcab_aes_gcm_decrypt_finish(atca_aes_gcm_ctx_t* ctx, const uint8_t*
         RETURN(status, "Tag calculation failed");
     }
 
-    *is_verified = (memcmp(calc_tag, tag, tag_size) == 0);
+    *is_verified = (atcab_memcmp(calc_tag, tag, tag_size) == 0);
 
     return ATCA_SUCCESS;
 }

--- a/lib/basic/atca_basic_secureboot.c
+++ b/lib/basic/atca_basic_secureboot.c
@@ -213,7 +213,7 @@ ATCA_STATUS atcab_secureboot_mac(uint8_t mode, const uint8_t* digest, const uint
             break;
         }
 
-        *is_verified = (memcmp(host_mac, mac, SECUREBOOT_MAC_SIZE) == 0);
+        *is_verified = (atcab_memcmp(host_mac, mac, SECUREBOOT_MAC_SIZE) == 0);
     }
     while (0);
 

--- a/lib/basic/atca_basic_verify.c
+++ b/lib/basic/atca_basic_verify.c
@@ -218,7 +218,7 @@ static ATCA_STATUS atcab_verify_extern_stored_mac(
             break;
         }
 
-        *is_verified = (memcmp(host_mac, mac, MAC_SIZE) == 0);
+        *is_verified = (atcab_memcmp(host_mac, mac, MAC_SIZE) == 0);
     }
     while (0);
 

--- a/lib/basic/atca_helpers.c
+++ b/lib/basic/atca_helpers.c
@@ -779,11 +779,12 @@ ATCA_STATUS atcab_base64decode(const char* encoded, size_t encoded_len, uint8_t*
  *  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  *  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *  *
- * \brief Compare two blocks of memory in constant time. Functions like memcmp()
+ * \brief Compare two blocks of memory in constant time. Functions like memcmp(),
+ *     but won't leak any data about the relative values of the blocks.
  * \param[in] block1_  Pointer to block of memory
  * \param[in] block2_  Pointer to block of memory
  * \param[in] num       Number of bytes to compare
- * \return an integral value indicating the relationship between the content of the memory blocks.
+ * \return 0 if the blocks are identical, 0xFF otherwise
  */
 int atcab_memcmp(const void* const block1_, const void* const block2_, size_t num)
 {

--- a/lib/basic/atca_helpers.c
+++ b/lib/basic/atca_helpers.c
@@ -760,4 +760,43 @@ ATCA_STATUS atcab_base64decode(const char* encoded, size_t encoded_len, uint8_t*
 }
 
 
+/**
+ * Function adapted from libsodium's sodium_memcmp()
+ *  * ISC License
+ *  *
+ *  * Copyright (c) 2013-2019
+ *  * Frank Denis <j at pureftpd dot org>
+ *  *
+ *  * Permission to use, copy, modify, and/or distribute this software for any
+ *  * purpose with or without fee is hereby granted, provided that the above
+ *  * copyright notice and this permission notice appear in all copies.
+ *  *
+ *  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *  *
+ * \brief Compare two blocks of memory in constant time. Functions like memcmp()
+ * \param[in] block1_  Pointer to block of memory
+ * \param[in] block2_  Pointer to block of memory
+ * \param[in] num       Number of bytes to compare
+ * \return an integral value indicating the relationship between the content of the memory blocks.
+ */
+int atcab_memcmp(const void* const block1_, const void* const block2_, size_t num)
+{
+    const volatile unsigned char* volatile block1 =
+            (const volatile unsigned char* volatile) block1_;
+    const volatile unsigned char* volatile block2 =
+            (const volatile unsigned char* volatile) block2_;
+    size_t i;
+    volatile unsigned char d = 0U;
 
+    for (i = 0U; i < num; i++)
+    {
+        d |= (unsigned)(block1[i] ^ block2[i]);
+    }
+    return (1U & ((d - 1U) >> 8U)) - 1;
+}

--- a/lib/basic/atca_helpers.h
+++ b/lib/basic/atca_helpers.h
@@ -72,6 +72,8 @@ ATCA_STATUS atcab_base64decode(const char* encoded, size_t encoded_size, uint8_t
 ATCA_STATUS atcab_base64encode_(const uint8_t* data, size_t data_size, char* encoded, size_t* encoded_size, const uint8_t * rules);
 ATCA_STATUS atcab_base64encode(const uint8_t* data, size_t data_size, char* encoded, size_t* encoded_size);
 
+int atcab_memcmp(const void* const block1_, const void* const block2_, size_t num);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add and use a constant-time memcmp (adapted from libsodium).