### PR TITLE
increase max I2C bus count

### DIFF
--- a/lib/hal/hal_linux_i2c_userspace.c
+++ b/lib/hal/hal_linux_i2c_userspace.c
@@ -111,12 +111,7 @@ ATCA_STATUS hal_i2c_init(void* hal, ATCAIfaceCfg* cfg)
             i2c_hal_data[bus] = malloc(sizeof(ATCAI2CMaster_t) );
             i2c_hal_data[bus]->ref_ct = 1;  // buses are shared, this is the first instance
 
-            switch (bus)
-            {
-            case 0: strcpy(i2c_hal_data[bus]->i2c_file, "/dev/i2c-0"); break;
-            case 1: strcpy(i2c_hal_data[bus]->i2c_file, "/dev/i2c-1"); break;
-            }
-
+            sprintf(i2c_hal_data[bus]->i2c_file, "/dev/i2c-%d",bus);
             // store this for use during the release phase
             i2c_hal_data[bus]->bus_index = bus;
         }

--- a/lib/hal/hal_linux_i2c_userspace.h
+++ b/lib/hal/hal_linux_i2c_userspace.h
@@ -35,7 +35,7 @@
  *
    @{ */
 
-#define MAX_I2C_BUSES   2   // Raspberry Pi has 2 TWI
+#define MAX_I2C_BUSES   32
 
 // A structure to hold I2C information
 typedef struct atcaI2Cmaster


### PR DESCRIPTION
I use ATECC608A on my UDOO x86 with i2c-tiny-usb module on I2C bus 11, so I modified some codes, to support more than 2 I2C bus.