### PR TITLE
Wrong index in pkcs11_config_parse_freeslots

### DIFF
--- a/lib/pkcs11/pkcs11_config.c
+++ b/lib/pkcs11/pkcs11_config.c
@@ -420,7 +420,7 @@ static CK_RV pkcs11_config_parse_freeslots(pkcs11_slot_ctx_ptr slot_ctx, char* c
 
     for (i = 0; i < 16; i++)
     {
-        uint32_t slot = strtol(argv[1], NULL, 10);
+        uint32_t slot = strtol(argv[i], NULL, 10);
         if (slot < 16)
         {
             slot_ctx->flags |= (1 << slot);

--- a/lib/pkcs11/pkcs11_config.c
+++ b/lib/pkcs11/pkcs11_config.c
@@ -418,7 +418,7 @@ static CK_RV pkcs11_config_parse_freeslots(pkcs11_slot_ctx_ptr slot_ctx, char* c
 
     pkcs11_config_split_string(cfgstr, ',', &argc, argv);
 
-    for (i = 0; i < 16; i++)
+    for (i = 0; i < argc; i++)
     {
         uint32_t slot = strtol(argv[i], NULL, 10);
         if (slot < 16)


### PR DESCRIPTION
Reading the slotnumbers from a pkcs11 config file did not work. This was caused by constatnly reading the slot number `argv[1]`  instead of `argv[i]` inside the loop traversing the values of the freeslots.