### PR TITLE
Restore windows build and token_random functionality

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,10 +61,10 @@ add_definitions(-DATCA_HAL_KIT_HID)
 set(CRYPTOAUTH_SRC ${CRYPTOAUTH_SRC} hal/kit_protocol.c hal/hal_all_platforms_kit_hidapi.c ${HID_SRC})
 endif(ATCA_HAL_KIT_HID)
 
-if(ATCA_HAL_I2C)
+if(LINUX AND ATCA_HAL_I2C)
 add_definitions(-DATCA_HAL_I2C)
 set(CRYPTOAUTH_SRC ${CRYPTOAUTH_SRC} ${TWI_SRC})
-endif(ATCA_HAL_I2C)
+endif(LINUX AND ATCA_HAL_I2C)
 
 if(ATCA_HAL_CUSTOM)
 add_definitions(-DATCA_HAL_CUSTOM)

--- a/lib/pkcs11/pkcs11_token.c
+++ b/lib/pkcs11/pkcs11_token.c
@@ -429,6 +429,7 @@ CK_RV pkcs11_token_random(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pRandomData, C
         if (32 < ulRandomLen)
         {
             memcpy(pRandomData, buf, 32);
+	    pRandomData += 32;
             ulRandomLen -= 32;
         }
         else


### PR DESCRIPTION
Windows PKCS11 isn't supported but the CMakeLists.txt should be correct for the python build when it is merged back.

Resolves #85 as well.