### PR TITLE
Update CMakeLists.txt with ATCA_USE_SHARED_MUTEX

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -103,6 +103,7 @@ target_link_libraries(cryptoauth ${IO_KIT_LIB} ${CORE_LIB})
 endif()
 
 if(LINUX)
+add_definitions(-DATCA_USE_SHARED_MUTEX)
 if(HAS_LIBUSB AND ATCA_HAL_KIT_HID)
 target_link_libraries(cryptoauth usb-1.0)
 elseif(HAS_UDEV AND ATCA_HAL_KIT_HID)


### PR DESCRIPTION
Fixes a deadlock issue when used directly with OpenSSL/libp11