### PR TITLE
Add missing break statement

### DIFF
--- a/lib/atcacert/atcacert_def.c
+++ b/lib/atcacert/atcacert_def.c
@@ -1710,6 +1710,7 @@ int atcacert_transform_data(atcacert_transform_t transform,
         {
             status = ATCA_SMALL_BUFFER;
         }
+        break;
     case TF_REVERSE:
         status = atcab_reversal(data, data_size, destination, destination_size);
         break;


### PR DESCRIPTION
It seems it's missing break statement in atcacert_transform_data function.
Based on documentation of atcacert_transform_e, TF_NONE is "no transform, data is used byte for byte" and TF_REVERSE is for "Reverse the bytes (e.g. change endianness)" but here the same behavior is done.
The pull request adds the missing break statement.