### PR TITLE
atca_basic_sign: check result

### DIFF
--- a/lib/basic/atca_basic_genkey.c
+++ b/lib/basic/atca_basic_genkey.c
@@ -79,7 +79,10 @@ ATCA_STATUS atcab_genkey_base(uint8_t mode, uint16_t key_id, const uint8_t* othe
 
         if (public_key && packet.data[ATCA_COUNT_IDX] > 4)
         {
-            memcpy(public_key, &packet.data[ATCA_RSP_DATA_IDX], packet.data[ATCA_COUNT_IDX] - 3);
+            if (packet.data[ATCA_COUNT_IDX] != 64 + ATCA_PACKET_OVERHEAD) {
+                return ATCA_ASSERT_FAILURE;
+            }
+            memcpy(public_key, &packet.data[ATCA_RSP_DATA_IDX], 64);
         }
     }
     while (0);

--- a/lib/basic/atca_basic_sign.c
+++ b/lib/basic/atca_basic_sign.c
@@ -75,7 +75,10 @@ ATCA_STATUS atcab_sign_base(uint8_t mode, uint16_t key_id, uint8_t *signature)
 
         if (packet.data[ATCA_COUNT_IDX] > 4)
         {
-            memcpy(signature, &packet.data[ATCA_RSP_DATA_IDX], packet.data[ATCA_COUNT_IDX] - ATCA_PACKET_OVERHEAD);
+            if (packet.data[ATCA_COUNT_IDX] != 64 + ATCA_PACKET_OVERHEAD) {
+                return ATCA_ASSERT_FAILURE;
+            }
+            memcpy(signature, &packet.data[ATCA_RSP_DATA_IDX], 64);
         }
 
     }


### PR DESCRIPTION
Avoids copying too many bytes.