### PR TITLE
basic: fix wrong reference / cast

### DIFF
--- a/lib/basic/atca_basic_read.c
+++ b/lib/basic/atca_basic_read.c
@@ -278,7 +278,7 @@ ATCA_STATUS atcab_read_enc(uint16_t key_id, uint8_t block, uint8_t *data, const 
         nonce_params.mode = NONCE_MODE_SEED_UPDATE;
         nonce_params.zero = 0;
         nonce_params.num_in = (uint8_t*)&num_in[0];
-        nonce_params.rand_out = (uint8_t*)&rand_out;
+        nonce_params.rand_out = rand_out;
         nonce_params.temp_key = &temp_key;
         if ((status = atcah_nonce(&nonce_params)) != ATCA_SUCCESS)
         {

--- a/lib/basic/atca_basic_write.c
+++ b/lib/basic/atca_basic_write.c
@@ -219,7 +219,7 @@ ATCA_STATUS atcab_write_enc(uint16_t key_id, uint8_t block, const uint8_t *data,
         nonce_params.mode = NONCE_MODE_SEED_UPDATE;
         nonce_params.zero = 0;
         nonce_params.num_in = (uint8_t*)&num_in[0];
-        nonce_params.rand_out = (uint8_t*)&rand_out;
+        nonce_params.rand_out = rand_out;
         nonce_params.temp_key = &temp_key;
 
         // Send the random Nonce command


### PR DESCRIPTION
num_in and rand_out are already `uint8_t*`. `(uint8_t*)&num_in` takes
the pointer of the pointer. By chance it happens to return the same
result for the stack var, but this is probably undefined behavior. In
any case, semantically it did not make any sense.