### PR TITLE
Mark slot available when its key is deleted via C_DestroyObject

### DIFF
--- a/app/pkcs11/example_pkcs11_config.c
+++ b/app/pkcs11/example_pkcs11_config.c
@@ -118,7 +118,7 @@ CK_RV pkcs11_config_load_objects(pkcs11_slot_ctx_ptr pSlot)
 			xLabel.pValue = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
             xLabel.ulValueLen = strlen(xLabel.pValue);
             xLabel.type = CKA_LABEL;
-			pkcs11_config_key(NULL, pSlot, pObject, &xLabel );
+			rv = pkcs11_config_key(NULL, pSlot, pObject, &xLabel );
 		}
 	}
     
@@ -131,7 +131,7 @@ CK_RV pkcs11_config_load_objects(pkcs11_slot_ctx_ptr pSlot)
 			xLabel.pValue = pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
             xLabel.ulValueLen = strlen(xLabel.pValue);
             xLabel.type = CKA_LABEL;
-			pkcs11_config_key(NULL, pSlot, pObject, &xLabel );
+			rv = pkcs11_config_key(NULL, pSlot, pObject, &xLabel );
 		}
 	}
 

--- a/lib/pkcs11/pkcs11_config.c
+++ b/lib/pkcs11/pkcs11_config.c
@@ -448,7 +448,7 @@ CK_RV pkcs11_config_key(pkcs11_lib_ctx_ptr pLibCtx, pkcs11_slot_ctx_ptr pSlot, p
 
     /* Find a free slot that matches the object type */
 
-    for (i = 0; i < 16; i++)
+    for (i = 0; i < PKCS11_MAX_OBJECTS_ALLOWED; i++)
     {
         if (pSlot->flags & (1 << i))
         {
@@ -490,8 +490,12 @@ CK_RV pkcs11_config_key(pkcs11_lib_ctx_ptr pLibCtx, pkcs11_slot_ctx_ptr pSlot, p
             fprintf(fp, "label = %s\n", pObject->name);
             fclose(fp);
         }
+        return CKR_OK;
     }
-    return CKR_OK;
+    else
+    {
+        return CKR_FUNCTION_FAILED;
+    }
 }
 
 CK_RV pkcs11_config_remove_object(pkcs11_lib_ctx_ptr pLibCtx, pkcs11_slot_ctx_ptr pSlot, pkcs11_object_ptr pObject)
@@ -501,6 +505,8 @@ CK_RV pkcs11_config_remove_object(pkcs11_lib_ctx_ptr pLibCtx, pkcs11_slot_ctx_pt
     (void)snprintf(filename, sizeof(filename), "%s%d.%d.conf", pLibCtx->config_path, pSlot->slot_id, pObject->slot);
 
     remove(filename);
+
+    pSlot->flags |= (1 << pObject->slot);
 
     return CKR_OK;
 }

--- a/lib/pkcs11/pkcs11_config.c
+++ b/lib/pkcs11/pkcs11_config.c
@@ -480,7 +480,7 @@ CK_RV pkcs11_config_key(pkcs11_lib_ctx_ptr pLibCtx, pkcs11_slot_ctx_ptr pSlot, p
         }
     }
 
-    if (i < 16)
+    if (i < PKCS11_MAX_OBJECTS_ALLOWED)
     {
         (void)snprintf(filename, sizeof(filename), "%s%d.%d.conf", pLibCtx->config_path, pSlot->slot_id, i);
         fp = fopen(filename, "wb");


### PR DESCRIPTION
Before this change, the object file would be deleted, but its slot would remain
marked as in-use. So a subsequence C_GenerateKeyPair would not find
any empty slots.

Also fix the code that finds an empty slot for a new key to return an error
if there are no empty slots. Before this change, it would pretend to succeed
and imply that slot 0 was available to write to.

Fixes #125