### PR TITLE
Bug fix for atca_mbedtls_cert_add (issue #109)

### DIFF
--- a/lib/hal/hal_pic32mz2048efm_i2c.c
+++ b/lib/hal/hal_pic32mz2048efm_i2c.c
@@ -142,7 +142,6 @@ ATCA_STATUS hal_i2c_send(ATCAIface iface, uint8_t *txdata, int txlength)
 
     txdata[0] = 0x03;   // insert the Word Address Value, Command token
     txlength++;         // account for word address value byte.
-    uint8_t tx = cfg->atcai2c.slave_address;
     write_bufHandle = DRV_I2C_Transmit(drvI2CMasterHandle, cfg->atcai2c.slave_address, txdata, txlength, NULL);
     if ( ((DRV_I2C_BUFFER_HANDLE)(-1)) == write_bufHandle)
     {
@@ -294,7 +293,6 @@ ATCA_STATUS hal_i2c_wake(ATCAIface iface)
     }
     else
     {
-        DRV_I2C_BUFFER_EVENT statusevent;
         // Send the wake by writing to an address of 0x00
         write_bufHandle = DRV_I2C_Transmit(drvI2CMasterHandle, cfg->atcai2c.slave_address, &data, 1, NULL);
         if ( ((DRV_I2C_BUFFER_HANDLE)(-1)) == write_bufHandle)

--- a/lib/mbedtls/atca_mbedtls_wrap.c
+++ b/lib/mbedtls/atca_mbedtls_wrap.c
@@ -181,7 +181,8 @@ int atca_mbedtls_cert_add(mbedtls_x509_crt * cert, const atcacert_def_t * cert_d
         }
     }
 
-    if (NULL == (cert_buf = mbedtls_calloc(1, cert_def->cert_template_size + 8)))
+    cert_len = cert_def->cert_template_size + 8;
+    if (NULL == (cert_buf = mbedtls_calloc(1, cert_len)))
     {
         ret = -1;
     }


### PR DESCRIPTION
This PR fixes the bug detailed in issue #109 where atcacert_read_cert is called without correctly initialising the cert_len parameter.
The PR also removes some unused variable declarations which were causing compilation warnings when using the PIC32MZ2048EF I2C HAL.