### PR TITLE
app: pkcs11: Update the template for device configuration

### DIFF
--- a/app/pkcs11/README.md
+++ b/app/pkcs11/README.md
@@ -153,9 +153,31 @@ Then edit 0.conf to match the device configuration being used.
 
 
 #### interface
-Allows values: 'hid', 'i2c'
-If using i2c specify the address in hex for the device. This is in the device format (upper
-7 bits define the address) so will not appear the same as the i2cdetect address (lower 7 bits)
+Required values: must be one of:
+```text
+    interface = i2c
+```
+
+```text
+    interface = hid
+```
+
+Optional values:
+If using i2c, one may update the default i2c configuration
+(cfg_ateccx08a_i2c_default) by specifying the address of the device, the i2c
+bus number and the i2c baud rate.
+
+```text
+    # Use I2C bus 2, address 0xC0, baud rate 1 MHz
+    interface = i2c,0xC0,2,1000000
+```
+
+The address of the device is in the device format (upper 7 bits define the
+address: 0xC0 in the example), so will not appear the same as the i2cdetect
+address (lower 7 bits: 0x60 in the example).
+
+hid interface will use the cfg_ateccx08a_kithid_default configuration and it
+can not be amended.
 
 #### freeslots
 This is a list of slots that may be used by the library when a pkcs11 operation that creates

--- a/app/pkcs11/README.md
+++ b/app/pkcs11/README.md
@@ -115,7 +115,8 @@ By default the following files will be created.
     # These are processed in order. Configuration parameters must be comma
     # delimited and may not contain spaces
 
-    interface = i2c,0xB0
+    # Use I2C bus 0, address 0xB0, baud rate 400 KHz
+    interface = i2c,0xB0,0,400000
     freeslots = 1,2,3
 
     # Slot 0 is the primary private key

--- a/app/pkcs11/slot.conf.tmpl
+++ b/app/pkcs11/slot.conf.tmpl
@@ -3,7 +3,8 @@
 # These are processed in order. Configuration parameters must be comma
 # delimited and may not contain spaces
 
-interface = i2c,0xB0
+# Use I2C bus 0, address 0xB0, baud rate 400 KHz
+interface = i2c,0xB0,0,400000
 freeslots = 1,2,3
 
 # Slot 0 is the primary private key


### PR DESCRIPTION
commit cf58f31b016a extended the i2c interface config to include the i2c bus number and i2c baud rate, but did not update the README or the template for the device configuration (slot.conf.tmpl).
Update the README and the template for the device configuration and describe the possible values for the "interface" field.