### PR TITLE
Fixed crash on using calib_ with own device

### DIFF
--- a/lib/atca_basic.c
+++ b/lib/atca_basic.c
@@ -78,7 +78,7 @@ ATCA_STATUS atcab_init_ext(ATCADevice* device, ATCAIfaceCfg *cfg)
         // If a device has already been initialized, release it
         if (*device)
         {
-            atcab_release();
+            atcab_release_ext(device);
         }
 
 #ifdef ATCA_NO_HEAP

--- a/lib/calib/calib_aes.c
+++ b/lib/calib/calib_aes.c
@@ -49,7 +49,7 @@
 ATCA_STATUS calib_aes(ATCADevice device, uint8_t mode, uint16_t key_id, const uint8_t* aes_in, uint8_t* aes_out)
 {
     ATCAPacket packet;
-    ATCACommand ca_cmd = _gDevice->mCommands;
+    ATCACommand ca_cmd = device->mCommands;
     ATCA_STATUS status = ATCA_GEN_FAIL;
 
     do

--- a/lib/calib/calib_basic.c
+++ b/lib/calib/calib_basic.c
@@ -254,7 +254,7 @@ ATCA_STATUS calib_get_zone_size(ATCADevice device, uint8_t zone, uint16_t slot, 
         default: status = ATCA_BAD_PARAM; break;
         }
     }
-    else if (_gDevice->mIface->mIfaceCFG->devtype == ATSHA206A)
+    else if (device->mIface->mIfaceCFG->devtype == ATSHA206A)
     {
         switch (zone)
         {

--- a/lib/calib/calib_basic.h
+++ b/lib/calib/calib_basic.h
@@ -11,6 +11,10 @@
  *
    @{ */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 ATCA_STATUS calib_wakeup(ATCADevice device);
 ATCA_STATUS calib_idle(ATCADevice device);
 ATCA_STATUS calib_sleep(ATCADevice device);
@@ -182,6 +186,10 @@ ATCA_STATUS calib_write_enc(ATCADevice device, uint16_t key_id, uint8_t block, c
 #endif
 
 ATCA_STATUS calib_write_config_counter(ATCADevice device, uint16_t counter_id, uint32_t counter_value);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 

--- a/lib/calib/calib_read.c
+++ b/lib/calib/calib_read.c
@@ -361,7 +361,7 @@ ATCA_STATUS calib_read_config_zone(ATCADevice device, uint8_t* config_data)
             break;
         }
 
-        if ((_gDevice->mIface->mIfaceCFG->devtype == ATSHA204A) || (_gDevice->mIface->mIfaceCFG->devtype == ATSHA206A))
+        if ((device->mIface->mIfaceCFG->devtype == ATSHA204A) || (device->mIface->mIfaceCFG->devtype == ATSHA206A))
         {
             status = calib_read_bytes_zone(device, ATCA_ZONE_CONFIG, 0, 0x00, config_data, ATCA_SHA_CONFIG_SIZE);
         }
@@ -432,7 +432,7 @@ ATCA_STATUS calib_cmp_config_zone(ATCADevice device, uint8_t* config_data, bool*
             break;
         }
 
-        if (_gDevice->mIface->mIfaceCFG->devtype == ATECC608A)
+        if (device->mIface->mIfaceCFG->devtype == ATECC608A)
         {
             /* Skip Counter[0], Counter[1], which can change during operation */
 

--- a/lib/calib/calib_sha.c
+++ b/lib/calib/calib_sha.c
@@ -286,7 +286,7 @@ ATCA_STATUS calib_hw_sha2_256_finish(ATCADevice device, atca_sha256_ctx_t* ctx, 
     uint32_t pad_zero_count;
     uint16_t digest_size;
 
-    if (_gDevice->mIface->mIfaceCFG->devtype == ATSHA204A)
+    if (device->mIface->mIfaceCFG->devtype == ATSHA204A)
     {
         // ATSHA204A only implements the raw 64-byte block operation, but
         // doesn't add in the final footer information. So we do that manually
@@ -456,7 +456,7 @@ ATCA_STATUS calib_sha_hmac_finish(ATCADevice device, atca_hmac_sha256_ctx_t *ctx
     uint8_t mode = SHA_MODE_HMAC_END;
     uint16_t digest_size = 32;
 
-    if (ATECC608A == _gDevice->mIface->mIfaceCFG->devtype)
+    if (ATECC608A == device->mIface->mIfaceCFG->devtype)
     {
         mode = SHA_MODE_608_HMAC_END;
     }

--- a/lib/calib/calib_sign.c
+++ b/lib/calib/calib_sign.c
@@ -122,7 +122,7 @@ ATCA_STATUS calib_sign(ATCADevice device, uint16_t key_id, const uint8_t *msg, u
         }
 
         // Load message into device
-        if (_gDevice->mCommands->dt == ATECC608A)
+        if (device->mCommands->dt == ATECC608A)
         {
             // Use the Message Digest Buffer for the ATECC608A
             nonce_target = NONCE_MODE_TARGET_MSGDIGBUF;

--- a/lib/calib/calib_verify.c
+++ b/lib/calib/calib_verify.c
@@ -258,7 +258,7 @@ ATCA_STATUS calib_verify_extern(ATCADevice device, const uint8_t *message, const
     do
     {
         // Load message into device
-        if (_gDevice->mCommands->dt == ATECC608A)
+        if (device->mCommands->dt == ATECC608A)
         {
             // Use the Message Digest Buffer for the ATECC608A
             nonce_target = NONCE_MODE_TARGET_MSGDIGBUF;
@@ -348,7 +348,7 @@ ATCA_STATUS calib_verify_stored(ATCADevice device, const uint8_t *message, const
     do
     {
         // Load message into device
-        if (_gDevice->mCommands->dt == ATECC608A)
+        if (device->mCommands->dt == ATECC608A)
         {
             // Use the Message Digest Buffer for the ATECC608A
             nonce_target = NONCE_MODE_TARGET_MSGDIGBUF;


### PR DESCRIPTION
1. _gDevice leftovers from migration from atcab_ to calib_
2. Added missed extern "C" in calib_basic.h