### PR TITLE
Fix compiler warning

### DIFF
--- a/lib/atca_basic.c
+++ b/lib/atca_basic.c
@@ -2489,7 +2489,7 @@ ATCA_STATUS atcab_read_config_zone(uint8_t* config_data)
  *
  * \return ATCA_SUCCESS on success, otherwise an error code.
  */
-ATCA_STATUS atcab_cmp_config_zone(uint8_t* config_data, bool* same_config)
+ATCA_STATUS atcab_cmp_config_zone(const uint8_t* const config_data, bool* same_config)
 {
     ATCA_STATUS status = ATCA_UNIMPLEMENTED;
     ATCADeviceType dev_type = atcab_get_device_type();

--- a/lib/atca_basic.h
+++ b/lib/atca_basic.h
@@ -545,7 +545,7 @@ ATCA_STATUS atcab_read_serial_number(uint8_t* serial_number);
 ATCA_STATUS atcab_read_pubkey(uint16_t slot, uint8_t* public_key);
 ATCA_STATUS atcab_read_sig(uint16_t slot, uint8_t* sig);
 ATCA_STATUS atcab_read_config_zone(uint8_t* config_data);
-ATCA_STATUS atcab_cmp_config_zone(uint8_t* config_data, bool* same_config);
+ATCA_STATUS atcab_cmp_config_zone(const uint8_t* const config_data, bool* same_config);
 
 #if defined(ATCA_USE_CONSTANT_HOST_NONCE)
 ATCA_STATUS atcab_read_enc(uint16_t key_id, uint8_t block, uint8_t* data, const uint8_t* enc_key, const uint16_t enc_key_id);

--- a/lib/calib/calib_basic.h
+++ b/lib/calib/calib_basic.h
@@ -124,7 +124,7 @@ ATCA_STATUS calib_read_serial_number(ATCADevice device, uint8_t* serial_number);
 ATCA_STATUS calib_read_pubkey(ATCADevice device, uint16_t slot, uint8_t *public_key);
 ATCA_STATUS calib_read_sig(ATCADevice device, uint16_t slot, uint8_t *sig);
 ATCA_STATUS calib_read_config_zone(ATCADevice device, uint8_t* config_data);
-ATCA_STATUS calib_cmp_config_zone(ATCADevice device, uint8_t* config_data, bool* same_config);
+ATCA_STATUS calib_cmp_config_zone(ATCADevice device, const uint8_t* const config_data, bool* same_config);
 // ECC204 Read command functions
 ATCA_STATUS calib_ecc204_read_zone(ATCADevice device, uint8_t zone, uint8_t slot, uint8_t block, size_t offset,
                                    uint8_t* data, uint8_t len);

--- a/lib/calib/calib_read.c
+++ b/lib/calib/calib_read.c
@@ -402,7 +402,7 @@ ATCA_STATUS calib_read_config_zone(ATCADevice device, uint8_t* config_data)
  *
  * \return ATCA_SUCCESS on success, otherwise an error code.
  */
-ATCA_STATUS calib_cmp_config_zone(ATCADevice device, uint8_t* config_data, bool* same_config)
+ATCA_STATUS calib_cmp_config_zone(ATCADevice device, const uint8_t* const config_data, bool* same_config)
 {
     ATCA_STATUS status = ATCA_GEN_FAIL;
     uint8_t device_config_data[ATCA_ECC_CONFIG_SIZE];   /** Max for all configs */


### PR DESCRIPTION
atcab_cmp_config_zone() and calib_cmp_config_zone() don't need
to be able to modify the config_data. When adding const keywords,
we are able to compare const data without a compiler warning.