### PR TITLE
Fix null pointer dereference when no phy is defined.

### DIFF
--- a/lib/hal/atca_hal.c
+++ b/lib/hal/atca_hal.c
@@ -332,10 +332,24 @@ ATCA_STATUS hal_iface_release(ATCAIfaceType iface_type, void *hal_data)
 
     if (ATCA_SUCCESS == status)
     {
-        status = hal->halrelease ? hal->halrelease(hal_data) : ATCA_BAD_PARAM;
-        status = phy->halrelease ? phy->halrelease(hal_data) : ATCA_BAD_PARAM;
-    }
+        if (hal && hal->halrelease)
+        {
+            status = hal->halrelease(hal_data);
+        }
+        else
+        {
+            status = ATCA_BAD_PARAM;
+        }
 
+        if (phy && phy->halrelease)
+        {
+            status |= phy->halrelease(hal_data);
+        }
+        else
+        {
+            status = ATCA_BAD_PARAM;
+        }
+    }
     return status;
 }
 


### PR DESCRIPTION
Check that the "hal" and "phy" pointers are not null before dereferencing.