### PR TITLE
pkcs11: Fix deadlock in pkcs11_token_init

### DIFF
--- a/lib/pkcs11/pkcs11_token.c
+++ b/lib/pkcs11/pkcs11_token.c
@@ -243,11 +243,7 @@ CK_RV pkcs11_token_init(CK_SLOT_ID slotID, CK_UTF8CHAR_PTR pPin, CK_ULONG ulPinL
         {
             if (64 != ulPinLen)
             {
-                if (CKR_OK == (rv = pkcs11_lock_context(pLibCtx)))
-                {
-                    rv = pkcs11_util_convert_rv(atcab_read_serial_number(buf));
-                    (void)pkcs11_unlock_context(pLibCtx);
-                }
+                rv = pkcs11_util_convert_rv(atcab_read_serial_number(buf));
 
                 if (CKR_OK == rv)
                 {


### PR DESCRIPTION
pkcs11_token_init() grabs the pContext->mutex at the beginning
of the function, locking the library. Later in the same function,
the code tries to grab the same lock, while already held. Mutexes
are not recursive in linux, resulting in a deadlock. Drop the
second attempt of grabbing the lock.

Signed-off-by: Tudor Ambarus <tudor.ambarus@microchip.com>