### PR TITLE
Fix for code generation errors with wolf

### DIFF
--- a/lib/crypto/atca_crypto_sw.h
+++ b/lib/crypto/atca_crypto_sw.h
@@ -87,10 +87,19 @@ typedef atca_evp_ctx atcac_pk_ctx;
 #include "wolfssl/wolfcrypt/hmac.h"
 #include "wolfssl/wolfcrypt/sha.h"
 #include "wolfssl/wolfcrypt/sha256.h"
+
 #include "wolfssl/wolfcrypt/error-crypt.h"
 #include "wolfssl/wolfcrypt/asn_public.h"
 #include "wolfssl/wolfcrypt/asn.h"
 #include "wolfssl/wolfcrypt/random.h"
+
+/* these must be defined before including ecc.h because it includes atca_basic.h, which expects atcac_sha2_256_ctx to be setup */
+typedef wc_Sha atcac_sha1_ctx;
+typedef wc_Sha256 atcac_sha2_256_ctx;
+typedef Cmac atcac_aes_cmac_ctx;
+typedef Hmac atcac_hmac_sha256_ctx;
+
+#include "wolfssl/wolfcrypt/ecc.h"
 
 typedef struct
 {
@@ -104,10 +113,6 @@ typedef struct
     void* ptr;
 } atca_wc_ctx;
 
-typedef wc_Sha atcac_sha1_ctx;
-typedef wc_Sha256 atcac_sha2_256_ctx;
-typedef Cmac atcac_aes_cmac_ctx;
-typedef Hmac atcac_hmac_sha256_ctx;
 typedef atca_wc_ctx atcac_pk_ctx;
 
 /* Some configurations end up with a circular definition the above have to be defined before include ecc.h (since ecc.h can call cryptoauthlib functions) */

--- a/lib/wolfssl/atca_wolfssl_interface.c
+++ b/lib/wolfssl/atca_wolfssl_interface.c
@@ -351,7 +351,7 @@ ATCA_STATUS atcac_pk_init(
     {
         if (!key_type)
         {
-            ctx->ptr = wc_ecc_key_new(NULL);
+            ctx->ptr = (ecc_key*)wc_ecc_key_new(NULL);
 
             if (ctx->ptr)
             {
@@ -413,11 +413,11 @@ ATCA_STATUS atcac_pk_init_pem(
             type = ECC_PUBLICKEY_TYPE;
         }
 
-        ret = PemToDer((unsigned char*)buf, (long)buflen, type, &der, NULL, NULL, &ecckey);
+        ret = PemToDer((const unsigned char*)buf, (long)buflen, type, &der, NULL, NULL, &ecckey);
 
         if ((ret >= 0) && (der != NULL))
         {
-            ctx->ptr = wc_ecc_key_new(NULL);
+            ctx->ptr = (ecc_key*)wc_ecc_key_new(NULL);
 
             if (ctx->ptr)
             {
@@ -509,7 +509,6 @@ ATCA_STATUS atcac_pk_sign(
     )
 {
     ATCA_STATUS status = ATCA_BAD_PARAM;
-    int ret = 0;
     WC_RNG rng;
 
     if (ctx && ctx->ptr && signature && digest && sig_len)


### PR DESCRIPTION
* Fixes Harmony code generator crashs like:


```
: library/cryptoauthlib/atca_config.h
<FreeMarker>[Error]: An exception was thrown while attempting to markup a template file: /Users/davidgarske/Harmony3/cryptoauthlib/harmony/templates/atca_config.h.ftl
<FreeMarker>[Error]: freemarker.core.InvalidReferenceException: The following has evaluated to null or missing:
==> plib_info[1]  [in template “atca_config.h.ftl” at line 108, column 6]
```
 
* Fix for issue with ecc.h include circular issue with atcac_sha2_256_c… 
* Fixes for cast and compiler warnings.
* Fix for redefinition of SHA2 macros.