### PR TITLE
Add missing include for atca_device.h

### DIFF
--- a/lib/mbedtls/atca_mbedtls_wrap.h
+++ b/lib/mbedtls/atca_mbedtls_wrap.h
@@ -35,6 +35,8 @@
  *
    @{ */
 
+#include "atca_device.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
The struct `ATCADevice` is used in `lib/mbedtls/atca_mbedtls_wrap.h` but it's header is not included. This leads to compilation in libraries using cryptoauthlib.