### PR TITLE
Fix no member named 'address' errors when using ATCA_ENABLE_DEPRECATED

### DIFF
--- a/lib/atca_basic.c
+++ b/lib/atca_basic.c
@@ -232,7 +232,11 @@ uint8_t atcab_get_device_address(ATCADevice device)
         switch (device->mIface.mIfaceCFG->iface_type)
         {
         case ATCA_I2C_IFACE:
+#ifdef ATCA_ENABLE_DEPRECATED
+            return device->mIface.mIfaceCFG->atcai2c.slave_address;
+#else
             return device->mIface.mIfaceCFG->atcai2c.address;
+#endif
         default:
             break;
         }

--- a/lib/atca_iface.c
+++ b/lib/atca_iface.c
@@ -153,7 +153,11 @@ ATCA_STATUS atsend(ATCAIface ca_iface, uint8_t address, uint8_t *txdata, int txl
 #ifdef ATCA_HAL_I2C
         if (ATCA_I2C_IFACE == ca_iface->mIfaceCFG->iface_type && 0xFF == address)
         {
+#ifdef ATCA_ENABLE_DEPRECATED
+            address = ca_iface->mIfaceCFG->atcai2c.slave_address;
+#else
             address = ca_iface->mIfaceCFG->atcai2c.address;
+#endif
         }
 #endif
 

--- a/lib/pkcs11/pkcs11_config.c
+++ b/lib/pkcs11/pkcs11_config.c
@@ -306,7 +306,11 @@ static CK_RV pkcs11_config_parse_interface(pkcs11_slot_ctx_ptr slot_ctx, char* c
         slot_ctx->interface_config.iface_type = ATCA_I2C_IFACE;
         if (argc > 1)
         {
+#ifdef ATCA_ENABLE_DEPRECATED
+            slot_ctx->interface_config.atcai2c.slave_address = (uint8_t)strtol(argv[1], NULL, 16);
+#else
             slot_ctx->interface_config.atcai2c.address = (uint8_t)strtol(argv[1], NULL, 16);
+#endif
         }
         if (argc > 2)
         {

--- a/lib/pkcs11/pkcs11_slot.c
+++ b/lib/pkcs11/pkcs11_slot.c
@@ -198,10 +198,17 @@ CK_RV pkcs11_slot_init(CK_SLOT_ID slotID)
     #ifdef ATCA_HAL_I2C
         if (ATCA_SUCCESS != status)
         {
+#ifdef ATCA_ENABLE_DEPRECATED
+            if (0xC0 != ifacecfg->atcai2c.slave_address)
+            {
+                /* Try the default address */
+                ifacecfg->atcai2c.slave_address = 0xC0;
+#else
             if (0xC0 != ifacecfg->atcai2c.address)
             {
                 /* Try the default address */
                 ifacecfg->atcai2c.address = 0xC0;
+#endif
                 atcab_release();
                 atca_delay_ms(1);
                 retries = 2;


### PR DESCRIPTION
When attempting to compile a project with `ATCA_ENABLE_DEPRECATED` defined, the compiler throws an error that it cannot find the member "address" since it's not a member of the `ATCAIfaceCfg` struct. This PR addresses all relevant instances of the member in question.



# Checklist
* [X] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
