### PR TITLE
Fix model number for ATECC608

### DIFF
--- a/lib/pkcs11/pkcs11_token.c
+++ b/lib/pkcs11/pkcs11_token.c
@@ -101,7 +101,7 @@ static char * pkcs11_token_device(ATCADeviceType dev_type, uint8_t info[4])
             rv = "ATECC508A";
             break;
         case 0x60:
-            if (0x02 < info[1])
+            if (info[3] >= 0x03)
             {
                 rv = "ATECC608B";
             }


### PR DESCRIPTION
Page 33 of the [doc](https://ww1.microchip.com/downloads/en/DeviceDoc/ATECC608A-TFLXTLS-CryptoAuthentication-Data-Sheet-DS40002138B.pdf) says that we should check the fourth byte of the output to determine the revision of the chip.
So the fourth byte is 0x02 for ATECC608A and greater or equal to 0x03(from the doc: "Over time the fourth byte for the ATECC608B could change if additional silicon enhancements are implemented.") for ATECC608B.

# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
