### PR TITLE
Add fixes to cryptoauthlib to support Java PKCS11 requirements, to support Greengrass V2

### DIFF
--- a/lib/pkcs11/pkcs11_key.c
+++ b/lib/pkcs11/pkcs11_key.c
@@ -513,12 +513,12 @@ const pkcs11_attrib_model pkcs11_key_private_attributes[] = {
     { CKA_SIGN_RECOVER,        NULL_PTR                                                                                                                                                                                                     },
     /** CK_TRUE if key supports unwrapping (i.e., can be used to unwrap other keys)9 */
     { CKA_UNWRAP,              NULL_PTR                                                                                                                                                                                                     },
-    /** CK_TRUE if key is extractable and can be wrapped 9 */
-    { CKA_EXTRACTABLE,         NULL_PTR                                                                                                                                                                                                     },
+    /** CK_TRUE if key is extractable and can be wrapped */
+    { CKA_EXTRACTABLE,         pkcs11_attrib_false                                                                                                                                                                                          },
     /** CK_TRUE if key has always had the CKA_SENSITIVE attribute set to CK_TRUE */
     { CKA_ALWAYS_SENSITIVE,    pkcs11_token_get_access_type                                                                                                                                                                                 },
     /** CK_TRUE if key has never had the CKA_EXTRACTABLE attribute set to CK_TRUE */
-    { CKA_NEVER_EXTRACTABLE,   NULL_PTR                                                                                                                                                                                                     },
+    { CKA_NEVER_EXTRACTABLE,   pkcs11_token_get_access_type                                                                                                                                                                                 },
     /** CK_TRUE if the key can only be wrapped with a wrapping key that has CKA_TRUSTED set to CK_TRUE. Default is CK_FALSE. */
     { CKA_WRAP_WITH_TRUSTED,   NULL_PTR                                                                                                                                                                                                     },
     /** For wrapping keys. The attribute template to match against any keys
@@ -639,11 +639,11 @@ const pkcs11_attrib_model pkcs11_key_secret_attributes[] = {
     /** CK_TRUE if key supports unwrapping (i.e., can be used to unwrap other keys) */
     { CKA_UNWRAP,             NULL_PTR                                                                                                                                                                            },
     /** CK_TRUE if key is extractable and can be wrapped */
-    { CKA_EXTRACTABLE,        NULL_PTR                                                                                                                                                                            },
+    { CKA_EXTRACTABLE,        pkcs11_attrib_false                                                                                                                                                                 },
     /** CK_TRUE if key has always had the CKA_SENSITIVE attribute set to CK_TRUE */
     { CKA_ALWAYS_SENSITIVE,   pkcs11_token_get_access_type                                                                                                                                                        },
     /** CK_TRUE if key has never had the CKA_EXTRACTABLE attribute set to CK_TRUE  */
-    { CKA_NEVER_EXTRACTABLE,  NULL_PTR                                                                                                                                                                            },
+    { CKA_NEVER_EXTRACTABLE,  pkcs11_token_get_access_type                                                                                                                                                        },
     /** Key checksum */
     { CKA_CHECK_VALUE,        pkcs11_key_get_check_value                                                                                                                                                          },
     /** CK_TRUE if the key can only be wrapped with a wrapping key that has CKA_TRUSTED set to CK_TRUE. Default is CK_FALSE. */

--- a/lib/pkcs11/pkcs11_signature.c
+++ b/lib/pkcs11/pkcs11_signature.c
@@ -148,6 +148,21 @@ CK_RV pkcs11_signature_sign(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_UL
                 return pkcs11_util_convert_rv(status);
             }
         }
+        else
+        {
+            switch (pSession->active_mech)
+            {
+            case CKM_SHA256_HMAC:
+                *pulSignatureLen = ATCA_SHA256_DIGEST_SIZE;
+                break;
+            case CKM_ECDSA:
+                *pulSignatureLen = ATCA_SIG_SIZE;
+                break;
+            default:
+                status = ATCA_GEN_FAIL;
+                break;
+            }
+        }
     }
     else
     {

--- a/lib/pkcs11/pkcs11_token.c
+++ b/lib/pkcs11/pkcs11_token.c
@@ -428,8 +428,8 @@ CK_RV pkcs11_token_get_info(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
     pInfo->ulMinPinLen = 0;
     pInfo->flags = CKF_RNG;// | CKF_LOGIN_REQUIRED;
 
-    pInfo->ulMaxSessionCount = 1;
-    pInfo->ulMaxRwSessionCount = 1;
+    pInfo->ulMaxSessionCount = PKCS11_MAX_SESSIONS_ALLOWED;
+    pInfo->ulMaxRwSessionCount = PKCS11_MAX_SESSIONS_ALLOWED;
 
     pInfo->ulSessionCount = (slot_ctx->session) ? TRUE : FALSE;
     pInfo->ulRwSessionCount = (slot_ctx->session) ? TRUE : FALSE;


### PR DESCRIPTION
# Please describe the purpose of this pull request
This PR fixes a number of issues that prevents Greengrass V2 using cryptoauthlib as a PKCS11 HSM provider. Note that for anyone browsing this PR, this also depends on a pending PR to add PKCS11 EC support to aws-c-io.

Greengrass V2 uses Java, which demands certain functionality of compliant PKCS11 libraries. In particular:
1) Java honors the maximum session limits, and needs at least two sessions (really three when taking into account aws-c-io).
2) Java requires the private key and certificate to have the same ID, which requires ID support
3) Java queries certain attributes such as CKA_EXTRACTABLE, which are supposed to be visible even on a private key

Additionally aws-c-io takes advantage of the ability to call C_Sign to determine size of buffer. This code path was unimplemented.

# Checklist
* [X] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
