### PR TITLE
Improve registration of dynamic HAL

### DIFF
--- a/lib/atca_config.h.in
+++ b/lib/atca_config.h.in
@@ -12,6 +12,7 @@
 #cmakedefine ATCA_HAL_SWI_UART
 #cmakedefine ATCA_HAL_1WIRE
 
+#cmakedefine ATCA_MAX_HAL_CACHE @ATCA_MAX_HAL_CACHE@
 
 /** Define to enable compatibility with legacy HALs
    (HALs with embedded device logic)*/

--- a/lib/hal/atca_hal.c
+++ b/lib/hal/atca_hal.c
@@ -253,6 +253,7 @@ static ATCA_STATUS hal_iface_set_registered(ATCAIfaceType iface_type, ATCAHAL_t*
         }
         else if (empty < atca_registered_hal_list_size)
         {
+            atca_registered_hal_list[empty].iface_type = iface_type;
             atca_registered_hal_list[empty].hal = hal;
             atca_registered_hal_list[empty].hal = phy;
             status = ATCA_SUCCESS;
@@ -284,7 +285,7 @@ ATCA_STATUS hal_iface_register_hal(ATCAIfaceType iface_type, ATCAHAL_t *hal, ATC
         status = hal_iface_set_registered(iface_type, hal, phy);
     }
 
-    return ATCA_SUCCESS;
+    return status;
 }
 
 /** \brief Standard HAL API for ATCA to initialize a physical interface


### PR DESCRIPTION
# Please describe the purpose of this pull request
Allow setting ATCA_MAX_HAL_CACHE from CMake so that you can register a HAL even when none were previously enabled. This also fixes a couple of minor bugs in related code.

This is an alternative to PR #298 for enabling a non-standard Zephyr I2C HAL implementation.


# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
