### PR TITLE
fix alignment of pkcs11_find_template_cache

### DIFF
--- a/lib/pkcs11/pkcs11_find.c
+++ b/lib/pkcs11/pkcs11_find.c
@@ -40,7 +40,8 @@
    @{ */
 
 //#ifdef ATCA_NO_HEAP
-static CK_BYTE pkcs11_find_template_cache[PKCS11_SEARCH_CACHE_SIZE];
+/* as we cast pointers to CK_ATTRIBUTE on this array later on, make sure it is also aligned that way */
+static CK_BYTE __attribute__ ((aligned(__alignof__(CK_ATTRIBUTE)))) pkcs11_find_template_cache[PKCS11_SEARCH_CACHE_SIZE];
 //#endif
 
 /**


### PR DESCRIPTION
align pkcs11_find_template_cache byte array to CK_ATTRIBUTE as it is used to store such structs by cast pointers

# Please describe the purpose of this pull request

Fixes issue #301

Depending on compiler optimization the byte array pkcs11_find_template_cache[] may have a lower alignment (1-byte) than struct CK_ATTRIBUTE (4-byte), which are byte-copied to in the array.
Therefore access to members of CK_ATTRIBUTE using cast pointers on the byte array may produce invalid results (or unaligned access exceptions, when activated).

# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
