### PR TITLE
Re-add support for getting the number of bytes needed for pkcs11 C_Sign

### DIFF
--- a/lib/pkcs11/pkcs11_signature.c
+++ b/lib/pkcs11/pkcs11_signature.c
@@ -234,7 +234,6 @@ CK_RV pkcs11_signature_verify_init(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR 
     {
         pSession->active_object = hKey;
         pSession->active_mech = pMechanism->mechanism;
-        rv = CKR_OK;
     }
     else
     {

--- a/lib/pkcs11/pkcs11_signature.c
+++ b/lib/pkcs11/pkcs11_signature.c
@@ -135,14 +135,28 @@ CK_RV pkcs11_signature_sign(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_UL
     case CKM_SHA256_HMAC:
         if (pSignature)
         {
-            rv = pkcs11_util_convert_rv(atcab_sha_hmac(pData, ulDataLen, pKey->slot, pSignature, SHA_MODE_TARGET_OUT_ONLY));
+            if (*pulSignatureLen < ATCA_SHA256_DIGEST_SIZE)
+            {
+                rv = CKR_BUFFER_TOO_SMALL;
+            }
+            else
+            {
+                rv = pkcs11_util_convert_rv(atcab_sha_hmac(pData, ulDataLen, pKey->slot, pSignature, SHA_MODE_TARGET_OUT_ONLY));
+            }
         }
         *pulSignatureLen = ATCA_SHA256_DIGEST_SIZE;
         break;
     case CKM_ECDSA:
         if (pSignature)
         {
-            rv = pkcs11_util_convert_rv(atcab_sign(pKey->slot, pData, pSignature));
+            if (*pulSignatureLen < ATCA_ECCP256_SIG_SIZE)
+            {
+                rv = CKR_BUFFER_TOO_SMALL;
+            }
+            else
+            {
+                rv = pkcs11_util_convert_rv(atcab_sign(pKey->slot, pData, pSignature));
+            }
         }
         *pulSignatureLen = ATCA_ECCP256_SIG_SIZE;
         break;
@@ -150,7 +164,7 @@ CK_RV pkcs11_signature_sign(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_UL
         rv = CKR_MECHANISM_INVALID;
         break;
     }
-    if (pSignature)
+    if (pSignature && CKR_BUFFER_TOO_SMALL != rv)
     {
         pSession->active_mech = CKM_VENDOR_DEFINED;
     }


### PR DESCRIPTION
# Please describe the purpose of this pull request

In e723fd0a the support for getting the number of bytes needed for the `C_Sign` operation was removed. :see_no_evil:

```
$ p11tool --provider=/usr/lib/libcryptoauth.so --test-sign 'pkcs11:object=device'
[..]
10:10:C_Sign:623:CKR_ARGUMENTS_BAD(7)
Cannot sign data: The request is invalid.
```
I assume this was not intentional and this PR re-adds support for it. I'm unsure which revision this library uses but I followed [§5.2 in PKCS#11 2.40](https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html#_Toc416959738). :rocket:

# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
