### PR TITLE
Simplify integration with mbedTLS 2.28.0

### DIFF
--- a/lib/mbedtls/atca_mbedtls_wrap.c
+++ b/lib/mbedtls/atca_mbedtls_wrap.c
@@ -1199,3 +1199,62 @@ int atca_mbedtls_cert_add(mbedtls_x509_crt * cert, const atcacert_def_t * cert_d
     return ret;
 }
 #endif
+
+int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid) {
+    switch (gid) {
+#ifdef MBEDTLS_ECP_DP_SECP192R1_ENABLED
+        case MBEDTLS_ECP_DP_SECP192R1:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_SECP224R1_ENABLED
+        case MBEDTLS_ECP_DP_SECP224R1:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_SECP256R1_ENABLED
+        case MBEDTLS_ECP_DP_SECP256R1:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_SECP384R1_ENABLED
+        case MBEDTLS_ECP_DP_SECP384R1:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_SECP521R1_ENABLED
+        case MBEDTLS_ECP_DP_SECP521R1:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_SECP192K1_ENABLED
+        case MBEDTLS_ECP_DP_SECP192K1:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_SECP224K1_ENABLED
+        case MBEDTLS_ECP_DP_SECP224K1:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_SECP256K1_ENABLED
+        case MBEDTLS_ECP_DP_SECP256K1:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_BP256R1_ENABLED
+        case MBEDTLS_ECP_DP_BP256R1:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_BP384R1_ENABLED
+        case MBEDTLS_ECP_DP_BP384R1:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_BP512R1_ENABLED
+        case MBEDTLS_ECP_DP_BP512R1:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_CURVE25519_ENABLED
+        case MBEDTLS_ECP_DP_CURVE25519:
+            return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_CURVE448_ENABLED
+        case MBEDTLS_ECP_DP_CURVE448:
+            return 0;
+#endif
+        default:
+            return 1;
+    }
+}

--- a/lib/mbedtls/atca_mbedtls_wrap.h
+++ b/lib/mbedtls/atca_mbedtls_wrap.h
@@ -79,6 +79,8 @@ int atca_mbedtls_ecdh_slot_cb(void);
  */
 int atca_mbedtls_ecdh_ioprot_cb(uint8_t secret[32]);
 
+int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# Description
This PR is related to issue #292
We're upgrading a product to the latest mbedTLS LTS branch ([2.28.1](https://github.com/Mbed-TLS/mbedtls/releases/tag/v2.28.1)). Upgrading from the previous LTS (2.16.X) was quite straightforward, Only `mbedtls_ecdsa_can_do` function was missing. This PR is fixing this.


# Checklist
* [X] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
