### PR TITLE
Minor fixes to support proper generation of libcryptoauth.dll in MinGW64/32

### DIFF
--- a/lib/atca_compiler.h
+++ b/lib/atca_compiler.h
@@ -119,7 +119,7 @@
 #define ATCA_UINT64_BE_TO_HOST(x)  __builtin_bswap64(x)
 #endif
 
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW64__) && !defined(__MINGW32__)
 #define SHARED_LIB_EXPORT       __declspec(dllexport)
 #define SHARED_LIB_IMPORT       __declspec(dllimport)
 #else
@@ -208,7 +208,7 @@
 #endif
 
 #ifdef ATCA_BUILD_SHARED_LIBS
-#if defined(cryptoauth_EXPORTS) && defined(_WIN32)
+#if defined(cryptoauth_EXPORTS) && defined(_WIN32) && !defined(_MINGW64__) && !defined(__MINGW32__)
 #define ATCA_DLL    SHARED_LIB_EXPORT
 #else
 #define ATCA_DLL    SHARED_LIB_IMPORT

--- a/test/api_atcab/atca_tests_sha.c
+++ b/test/api_atcab/atca_tests_sha.c
@@ -193,17 +193,17 @@ static void hex_to_uint8(const char hex_str[2], uint8_t* num)
         TEST_FAIL_MESSAGE("Not a hex digit.");
     }
 }
-void hex_to_data(const char* hex_str, uint8_t* data, size_t data_size)
-{
-    size_t i = 0;
+// void hex_to_data(const char* hex_str, uint8_t* data, size_t data_size)
+// {
+//     size_t i = 0;
 
-    TEST_ASSERT_EQUAL_MESSAGE(data_size * 2, strlen(hex_str) - 1, "Hex string unexpected length.");
+//     TEST_ASSERT_EQUAL_MESSAGE(data_size * 2, strlen(hex_str) - 1, "Hex string unexpected length.");
 
-    for (i = 0; i < data_size; i++)
-    {
-        hex_to_uint8(&hex_str[i * 2], &data[i]);
-    }
-}
+//     for (i = 0; i < data_size; i++)
+//     {
+//         hex_to_uint8(&hex_str[i * 2], &data[i]);
+//     }
+// }
 static int read_rsp_hex_value(FILE* file, const char* name, uint8_t* data, size_t data_size)
 {
     char line[16384];

--- a/test/api_crypto/test_crypto_sha.c
+++ b/test/api_crypto/test_crypto_sha.c
@@ -154,7 +154,7 @@ static void hex_to_uint8(const char hex_str[2], uint8_t* num)
     }
 }
 
-static void hex_to_data(const char* hex_str, uint8_t* data, size_t data_size)
+void hex_to_data(const char* hex_str, uint8_t* data, size_t data_size)
 {
     size_t i = 0;
 

--- a/third_party/hidapi/hidapi/hidapi.h
+++ b/third_party/hidapi/hidapi/hidapi.h
@@ -29,7 +29,7 @@
 
 #include <wchar.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW64__) && !defined(__MINGW32__)
       #define HID_API_EXPORT __declspec(dllexport)
       #define HID_API_CALL
 #else


### PR DESCRIPTION
This pull request is intended to fix the 'multiple definitions' errors that prevent the correct compilation of the project with MinGW64 and MinGW32 using gcc version 12.2.0, with BUILD_SHARED_LIBS option enabled.

It also avoids an additional 'multiple definitions' error when compiling the test executable concerning the 'hex_to_data' function.


# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
