### PR TITLE
Sleep instead of busy wait for Zephyr hal_delay_ms

### DIFF
--- a/third_party/hal/zephyr/hal_zephyr.c
+++ b/third_party/hal/zephyr/hal_zephyr.c
@@ -65,7 +65,7 @@ void hal_delay_10us(uint32_t delay)
 /* ASF already has delay_ms - see delay.h */
 void hal_delay_ms(uint32_t delay)
 {
-    hal_delay_us(delay * 1000);
+    k_msleep(delay);
 }
 
 


### PR DESCRIPTION
Allows Zephyr to schedule other threads during the delay.