### PR TITLE
pkcs11:avoid returning value overwriting

### DIFF
--- a/lib/pkcs11/pkcs11_init.c
+++ b/lib/pkcs11/pkcs11_init.c
@@ -359,9 +359,13 @@ CK_RV pkcs11_init(CK_C_INITIALIZE_ARGS_PTR pInitArgs)
         if (CKR_OK == rv)
         {
             lib_ctx->initialized = TRUE;
+            rv = pkcs11_unlock_both(lib_ctx);
         }
-
-        rv = pkcs11_unlock_both(lib_ctx);
+        else
+        {
+            /* Unlock the device, but preserve rv value from previous calls */
+            pkcs11_unlock_both(lib_ctx);
+        }
     }
 
     return rv;


### PR DESCRIPTION
When configuration(s) is incorrect, overwriting of returned value allows the init procedure to move forward instead of stopping. It triggers fails in later steps, which sometimes look not too much obvious. This change removes the rv value overwriting.


Here is an example. I pushed 2 configs which triggered an error. 

Original version:
```
PKCS#11: Initializing the engine
7011:7011:C_Initialize:141:
7011:7011:pkcs11_config_load_objects:892:Opening Configuration: /etc/tmp/0.conf
7011:7011:pkcs11_config_load_objects:892:Opening Configuration: /etc/tmp/slot.conf
7011:7011:pkcs11_config_load_objects:909:Tried to reload the same configuration file for the same slot
7011:7011:C_Initialize:142:CKR_OK(0)
7011:7011:C_GetInfo:159:
7011:7011:C_GetInfo:160:CKR_CRYPTOKI_NOT_INITIALIZED(190)
7011:7011:C_Finalize:150:
7011:7011:C_Finalize:151:CKR_CRYPTOKI_NOT_INITIALIZED(190)
Unable to load module /usr/lib/libcryptoauth.so
```

Modified version:
```
PKCS#11: Initializing the engine
7359:7359:C_Initialize:141:
7359:7359:pkcs11_config_load_objects:892:Opening Configuration: /etc/tmp/0.conf
7359:7359:pkcs11_config_load_objects:892:Opening Configuration: /etc/tmp/slot.conf
7359:7359:pkcs11_config_load_objects:909:Tried to reload the same configuration file for the same slot
7359:7359:C_Initialize:142:CKR_GENERAL_ERROR(5)
Unable to load module /usr/lib/libcryptoauth.so
```

# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
