### PR TITLE
[os-2426] Apply patch to make it build on ESP32S3

### DIFF
--- a/lib/mbedtls/atca_mbedtls_ecdsa.c
+++ b/lib/mbedtls/atca_mbedtls_ecdsa.c
@@ -26,12 +26,23 @@
  */
 
 /* mbedTLS boilerplate includes */
+#include "mbedtls/version.h"
 
+#if (MBEDTLS_VERSION_NUMBER < 0x03000000)
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+/**
+ * Mbedtls-3.0 forward compatibility
+ */
+#ifndef MBEDTLS_PRIVATE
+#define MBEDTLS_PRIVATE(member) member
+#endif
+#else /* (MBEDTLS_VERSION_NUMBER < 0x03000000) */
+#include "mbedtls/build_info.h"
+#endif /* !(MBEDTLS_VERSION_NUMBER < 0x03000000) */
 
 #if defined(MBEDTLS_ECDSA_C)
 
@@ -130,18 +141,18 @@ int mbedtls_ecdsa_verify(mbedtls_ecp_group *grp,
         ret = mbedtls_mpi_write_binary(s, &raw_sig[ATCA_SIG_SIZE / 2], ATCA_SIG_SIZE / 2);
     }
 
-    if (Q->Z.n == 1)
+    if (Q->MBEDTLS_PRIVATE(Z).MBEDTLS_PRIVATE(n) == 1)
     {
         uint8_t public_key[ATCA_PUB_KEY_SIZE];
 
         /* Convert the public key to it's uncompressed binary */
         if (!ret)
         {
-            ret = mbedtls_mpi_write_binary(&(Q->X), public_key, ATCA_PUB_KEY_SIZE / 2);
+            ret = mbedtls_mpi_write_binary(&(Q->MBEDTLS_PRIVATE(X)), public_key, ATCA_PUB_KEY_SIZE / 2);
         }
         if (!ret)
         {
-            ret = mbedtls_mpi_write_binary(&(Q->Y), &public_key[ATCA_PUB_KEY_SIZE / 2], ATCA_PUB_KEY_SIZE / 2);
+            ret = mbedtls_mpi_write_binary(&(Q->MBEDTLS_PRIVATE(Y)), &public_key[ATCA_PUB_KEY_SIZE / 2], ATCA_PUB_KEY_SIZE / 2);
         }
 
         if (!ret)
@@ -159,7 +170,7 @@ int mbedtls_ecdsa_verify(mbedtls_ecp_group *grp,
         atca_mbedtls_eckey_t key_info;
         if (!ret)
         {
-            ret = mbedtls_mpi_write_binary(&Q->Z, (unsigned char*)&key_info, sizeof(atca_mbedtls_eckey_t));
+            ret = mbedtls_mpi_write_binary(&Q->MBEDTLS_PRIVATE(Z), (unsigned char*)&key_info, sizeof(atca_mbedtls_eckey_t));
         }
 
         if (!ret)


### PR DESCRIPTION
To make cryptoauthlib compatible with ESP-IDF on teh ESP32S3, some changes are needed.
