### PR TITLE
Fix symmetric_authenticate app.

### DIFF
--- a/app/ip_protection/symmetric_authentication.c
+++ b/app/ip_protection/symmetric_authentication.c
@@ -44,14 +44,12 @@ ATCA_STATUS symmetric_authenticate(uint8_t slot, const uint8_t *master_key, cons
 {
     ATCA_STATUS status;
     uint8_t sn[ATCA_SERIAL_NUM_SIZE];
-    uint8_t symmetric_key[ATCA_KEY_SIZE];
-    atca_temp_key_t temp_key, temp_key_derive;
+    atca_temp_key_t temp_key;
     uint8_t rand_out[RANDOM_NUM_SIZE];
     atca_nonce_in_out_t nonce_params;
     atca_mac_in_out_t mac_params;
     uint8_t host_mac[MAC_SIZE];
     uint8_t device_mac[MAC_SIZE];
-    struct atca_derive_key_in_out derivekey_params;
 
     do
     {
@@ -82,30 +80,12 @@ ATCA_STATUS symmetric_authenticate(uint8_t slot, const uint8_t *master_key, cons
             break;
         }
 
-        memset(&temp_key_derive, 0, sizeof(temp_key_derive));
-        temp_key_derive.valid = 1;
-        memcpy(temp_key_derive.value, sn, sizeof(sn)); // 32 bytes TempKey ( SN[0:8] with padded 23 zeros used in symmetric key calculation)
-
-        // Parameters used deriving the symmetric key
-        derivekey_params.mode = 0;
-        derivekey_params.target_key_id = slot;
-        derivekey_params.parent_key = master_key;
-        derivekey_params.sn = sn;
-        derivekey_params.target_key = symmetric_key;
-        derivekey_params.temp_key = &temp_key_derive;
-
-        // calculate the symmetric_diversified_key
-        if ((status = atcah_derive_key(&derivekey_params)) != ATCA_SUCCESS)
-        {
-            break;
-        }
-
         // Setup MAC command
         memset(&mac_params, 0, sizeof(mac_params));
         mac_params.mode = MAC_MODE_BLOCK2_TEMPKEY | MAC_MODE_INCLUDE_SN; // Block 1 is a key, block 2 is TempKey
         mac_params.key_id = slot;
         mac_params.challenge = NULL;
-        mac_params.key = symmetric_key;
+        mac_params.key = master_key;
         mac_params.otp = NULL;
         mac_params.sn = sn;
         mac_params.response = host_mac;


### PR DESCRIPTION
The function symmetric_authenticate didn't work for the atsha204a. The host_mac and device_mac did not match. This was due to the fact that on the host side a key was derived whereas this was not done on the device side.

The way I fixed it is to not do the key derivation on the host side, this fixed the problem.

# Please describe the purpose of this pull request



# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
