### PR TITLE
hal: zephyr: fix device / word address issues with i2c writes

### DIFF
--- a/third_party/hal/zephyr/hal_zephyr_i2c.c
+++ b/third_party/hal/zephyr/hal_zephyr_i2c.c
@@ -111,19 +111,36 @@ ATCA_STATUS hal_i2c_post_init(ATCAIface iface)
  * \return ATCA_SUCCESS on success, otherwise an error code.
  */
 
-ATCA_STATUS hal_i2c_send(ATCAIface iface, uint8_t address, uint8_t *txdata, int txlength)
+ATCA_STATUS hal_i2c_send(ATCAIface iface, uint8_t word_address, uint8_t *txdata, int txlength)
 {
     struct device * zdev = (struct device *)atgetifacehaldat(iface);
-
-    if (!zdev || (0 == txlength) || (NULL == txdata))
+    if (!zdev)
     {
         return ATCA_BAD_PARAM;
     }
-    if (i2c_write(zdev, txdata, txlength, (address >> 0x1)))
+    ATCAIfaceCfg *cfg = atgetifacecfg(iface);
+    if (!cfg)
+    {
+        return ATCA_BAD_PARAM;
+    }
+
+    uint8_t device_address = 0xFFu;
+#ifdef ATCA_ENABLE_DEPRECATED
+    device_address = ATCA_IFACECFG_VALUE(cfg, atcai2c.slave_address);
+#else
+    device_address = ATCA_IFACECFG_VALUE(cfg, atcai2c.address);
+#endif
+
+    if ((0 == txlength) || (NULL == txdata))
+    {
+        return ATCA_BAD_PARAM;
+    }
+
+    if (i2c_write(zdev, txdata, txlength, (device_address >> 0x1)))
     {
         return ATCA_TX_FAIL;
     }
-     
+
     return ATCA_SUCCESS;
 }
 

--- a/third_party/hal/zephyr/hal_zephyr_i2c.c
+++ b/third_party/hal/zephyr/hal_zephyr_i2c.c
@@ -131,9 +131,9 @@ ATCA_STATUS hal_i2c_send(ATCAIface iface, uint8_t word_address, uint8_t *txdata,
     device_address = ATCA_IFACECFG_VALUE(cfg, atcai2c.address);
 #endif
 
-    if ((0 == txlength) || (NULL == txdata))
-    {
-        return ATCA_BAD_PARAM;
+    if ((0 == txlength) || (NULL == txdata)) {
+        txdata = &word_address;
+        txlength = 1;
     }
 
     if (i2c_write(zdev, txdata, txlength, (device_address >> 0x1)))


### PR DESCRIPTION
# Please describe the purpose of this pull request

Fixes use of word address as device address in i2c writes.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

Some callers pass a word address, but empty data buffer, when issuing
i2c writes, such as when waking a device. Typically the HAL is passed a
data buffer that includes the word address as the first byte, but when
the data buffer is empty we opt to instead use the 1 byte word address
as the data to be written.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
