### PR TITLE
Fix: hal_iface_init() is not using malloc() anymore when ATCA_NO_HEAP…

### DIFF
--- a/lib/hal/atca_hal.c
+++ b/lib/hal/atca_hal.c
@@ -153,6 +153,11 @@ typedef struct
 } atca_hal_list_entry_t;
 
 
+#if defined(ATCA_NO_HEAP) && defined(ATCA_HAL_CUSTOM)
+    static ATCAHAL_t g_atcahal_custom_iface;
+#endif
+
+
 static atca_hal_list_entry_t atca_registered_hal_list[ATCA_MAX_HAL_CACHE] = {
 #ifdef ATCA_HAL_I2C
     { (uint8_t)ATCA_I2C_IFACE,      &hal_i2c,        NULL      },
@@ -305,7 +310,12 @@ ATCA_STATUS hal_iface_init(ATCAIfaceCfg *cfg, ATCAHAL_t **hal, ATCAHAL_t **phy)
 #ifdef ATCA_HAL_CUSTOM
         if (ATCA_CUSTOM_IFACE == cfg->iface_type)
         {
+#ifdef ATCA_NO_HEAP
+            (void)memset(&g_atcahal_custom_iface, 0, sizeof(g_atcahal_custom_iface));
+            *hal = &g_atcahal_custom_iface;
+#else
             *hal = hal_malloc(sizeof(ATCAHAL_t));
+#endif
             if (NULL != *hal)
             {
                 (*hal)->halinit = ATCA_IFACECFG_VALUE(cfg, atcacustom.halinit);


### PR DESCRIPTION
# ATCA_NO_HEAP does not cover the custom-HAL allocation in hal_iface_init()

## Affected versions
- v3.8.0 (`d49c7d5`)

## Configuration
Bare-metal target (**no heap**), built with:

```
-DATCA_NO_HEAP=ON -DATCA_HAL_CUSTOM=ON
```

## Problem
With `ATCA_NO_HEAP` defined, the library is documented (and annotated) to perform no
dynamic memory allocation. However, `hal_iface_init()` (`lib/hal/atca_hal.c`) allocates the custom-HAL
function-pointer struct unconditionally when `ATCA_CUSTOM_IFACE` is used
(`lib/hal/atca_hal.c:306-308`, v3.8.0):

```c
#ifdef ATCA_HAL_CUSTOM
        if (ATCA_CUSTOM_IFACE == cfg->iface_type)
        {
            *hal = hal_malloc(sizeof(ATCAHAL_t));   /* not gated by ATCA_NO_HEAP */
```

## Observed behaviour
On a heapless target (`malloc` returns NULL), `atcab_init()` with a
custom-HAL `ATCAIfaceCfg` fails with `ATCA_ALLOC_FAILURE`.

## Expected behaviour
With `ATCA_NO_HEAP` defined, no code path calls `hal_malloc`/`hal_free`.

## Suggested fix
When using `ATCA_NO_HEAP`, use a static `ATCAHAL_t` instance in `hal_iface_init()` .