### PR TITLE
hal_esp32_i2c: fix dangling pointer bug

### DIFF
--- a/lib/hal/hal_esp32_i2c.c
+++ b/lib/hal/hal_esp32_i2c.c
@@ -250,6 +250,7 @@ ATCA_STATUS hal_i2c_send(ATCAIface iface, uint8_t word_address, uint8_t *txdata,
     }
 
     (void)i2c_master_bus_rm_device(i2c_hal_data[bus].dev_handle);
+    i2c_hal_data[bus].dev_handle = NULL;
     
 #endif
 
@@ -317,6 +318,7 @@ ATCA_STATUS hal_i2c_receive(ATCAIface iface, uint8_t address, uint8_t *rxdata, u
     }
 
     (void)i2c_master_bus_rm_device(i2c_hal_data[bus].dev_handle);
+    i2c_hal_data[bus].dev_handle = NULL;
 
 #endif
 
@@ -341,6 +343,7 @@ ATCA_STATUS hal_i2c_release(void *hal_data)
 
     if (hal->dev_handle) {
         rc = i2c_master_bus_rm_device(hal->dev_handle);
+        hal->dev_handle = NULL;
     }
 
     if (hal && --(hal->ref_ct) <= 0)


### PR DESCRIPTION
# Purpose of this pull request
Fixes #425 

Current implementation left dangling pointer, which led to double free and heap poisoning in ESP32-C6 as described in #425. Assigned NULL to each pointer given as argument in `i2c_master_bus_rm_device()` after the call of the function.


# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
