### PR TITLE
test(aes_ccm): fix incompatible-pointer-types warning in NIST vector test

### DIFF
--- a/test/api_atcab/atca_tests_aes_ccm.c
+++ b/test/api_atcab/atca_tests_aes_ccm.c
@@ -597,8 +597,10 @@ static ATCA_STATUS aes_ccm_nist_vector_test(ccm_nist_vt_types_t ccm_nist_type)
             status = atcab_aes_ccm_encrypt_update(&ctx, plaintext, ptlen, ciphertext);
             TEST_ASSERT_EQUAL(ATCA_SUCCESS, status);
 
-            status = atcab_aes_ccm_encrypt_finish(&ctx, tag, &taglen);
+            uint8_t tag_size_u8 = (uint8_t)taglen;
+            status = atcab_aes_ccm_encrypt_finish(&ctx, tag, &tag_size_u8);
             TEST_ASSERT_EQUAL(ATCA_SUCCESS, status);
+            taglen = tag_size_u8;
 
             if(0 != cipherlen)
             {


### PR DESCRIPTION
atcab_aes_ccm_encrypt_finish() expects a uint8_t* for the tag size, but aes_ccm_nist_vector_test() was passing the address of a size_t `taglen`, producing:

  atca_tests_aes_ccm.c:600:62: error: passing argument 3 of
  'atcab_aes_ccm_encrypt_finish' from incompatible pointer type
  [-Wincompatible-pointer-types]

Casting the size_t* to uint8_t* would only overwrite the low byte and leave the remaining bytes with stale content (and produce a wrong value on big-endian). Use a local uint8_t for the API call and write the result back into `taglen` so the subsequent
TEST_ASSERT_EQUAL_MEMORY(expected_tag, tag, taglen) sees the length returned by the API.

# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
