### PR TITLE
pkcs11: bound the config file index in pkcs11_config_load_objects()

### DIFF
--- a/lib/pkcs11/pkcs11_config.c
+++ b/lib/pkcs11/pkcs11_config.c
@@ -1078,21 +1078,32 @@ CK_RV pkcs11_config_load_objects(pkcs11_slot_ctx_ptr slot_ctx)
                     /* Configuration files must end with ".conf" */
                     if (0 == strcmp(&de->d_name[fn_len - 5u], ".conf"))
                     {
-                        /* coverity[misra_c_2012_directive_4_12_violation] Standard library functions are required */
-                        /* coverity[misra_c_2012_rule_21_3_violation] Standard library functions are required */
-                        updateConfFileData[i] = (pkcs11_conf_filedata*)malloc(sizeof(pkcs11_conf_filedata));
-
-                        if (NULL != updateConfFileData[i])
+                        if (MAX_CONF_FILES <= i)
                         {
-                            (void)strcpy(updateConfFileData[i]->filename, de->d_name);
-                            updateConfFileData[i]->initialized = false;
+                            /* More configuration files than updateConfFileData
+                               can hold. Report it rather than silently ignoring
+                               the remainder, which files get ignored would
+                               otherwise depend on readdir() order. */
+                            rv = CKR_HOST_MEMORY;
+                        }
+                        else
+                        {
+                            /* coverity[misra_c_2012_directive_4_12_violation] Standard library functions are required */
+                            /* coverity[misra_c_2012_rule_21_3_violation] Standard library functions are required */
+                            updateConfFileData[i] = (pkcs11_conf_filedata*)malloc(sizeof(pkcs11_conf_filedata));
 
-                            if (UINT8_MAX > totalConfFileCount)
+                            if (NULL != updateConfFileData[i])
                             {
-                                totalConfFileCount++;
+                                (void)strcpy(updateConfFileData[i]->filename, de->d_name);
+                                updateConfFileData[i]->initialized = false;
+
+                                if (UINT8_MAX > totalConfFileCount)
+                                {
+                                    totalConfFileCount++;
+                                }
+                                i++;
                             }
                         }
-                        i++;
                     }
                 }
             }
@@ -1111,7 +1122,7 @@ CK_RV pkcs11_config_load_objects(pkcs11_slot_ctx_ptr slot_ctx)
 
     argc = sizeof(argv) / sizeof(argv[0]);
     /* First parse base file and then parse handle files if present*/
-    while (NULL != updateConfFileData[i])
+    while ((totalConfFileCount > i) && (NULL != updateConfFileData[i]))
     {
         size_t fileName_len = strlen(updateConfFileData[i]->filename);
         (void)memcpy((void*)fileName_tmp, (const void*)updateConfFileData[i]->filename, sizeof(updateConfFileData[i]->filename));
@@ -1362,7 +1373,7 @@ CK_RV pkcs11_config_load_objects(pkcs11_slot_ctx_ptr slot_ctx)
         i++;
     }
 
-    for (i = 0; NULL != updateConfFileData[i]; i++)
+    for (i = 0; (totalConfFileCount > i) && (NULL != updateConfFileData[i]); i++)
     {
         pkcs11_os_free(updateConfFileData[i]);
     }


### PR DESCRIPTION
[`updateConfFileData[MAX_CONF_FILES]`](https://github.com/MicrochipTech/cryptoauthlib/blob/d49c7d57/lib/pkcs11/pkcs11_config.c#L1015) is indexed by `i`, which nothing bounds — `MAX_CONF_FILES` appears only in its `#define` and that declaration, never in a comparison.

Under AddressSanitizer at `d49c7d5`, varying only the number of `.conf` files in the filestore:

```
15 files   ok
16 files   stack-buffer-overflow READ  of size 8 at :1114
17 files   stack-buffer-overflow WRITE of size 8 at :1083
```

Two defects, not one. At 17 the [store](https://github.com/MicrochipTech/cryptoauthlib/blob/d49c7d57/lib/pkcs11/pkcs11_config.c#L1083) writes past the end. At 16 nothing is written out of bounds — the array is merely full, so the `NULL` that the [parse walk](https://github.com/MicrochipTech/cryptoauthlib/blob/d49c7d57/lib/pkcs11/pkcs11_config.c#L1114) and the [free walk](https://github.com/MicrochipTech/cryptoauthlib/blob/d49c7d57/lib/pkcs11/pkcs11_config.c#L1365) rely on as a terminator no longer exists. Bounding the store alone leaves 16 broken, so both walks are bounded by `totalConfFileCount` too.

16 is a normal configuration, not a crafted one: a slot with N objects is `1 + N` files (`0.conf` plus `0.<handle>.conf`), so the default `PKCS11_MAX_OBJECTS_ALLOWED=16` needs 17.

`i++` also moves inside the allocation-success branch, so `i` and `totalConfFileCount` cannot diverge; on a failed `malloc` the old code left a `NULL` hole that truncates one consumer loop and is dereferenced by the other.

To reproduce: put `0.conf` and `0.2.conf` … `0.17.conf` in a filestore and call `C_Initialize()` on a build with `-fsanitize=address`.

Open question: `MAX_CONF_FILES` is `PKCS11_MAX_SLOTS_ALLOWED * PKCS11_MAX_OBJECTS_ALLOWED`, counting neither the per-slot base file nor the `NULL` these loops need. Resizing it changes stack usage on embedded targets, so this patch only bounds the index — happy to follow up with the resize if you would prefer that.

# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
